### PR TITLE
Add 'in' operator to WHERE

### DIFF
--- a/src/erma_utils.erl
+++ b/src/erma_utils.erl
@@ -76,6 +76,7 @@ prepare_value([$$ | Rest] = Value) -> % postgresql placeholder
     end;
 prepare_value(Value) when is_integer(Value) -> integer_to_list(Value);
 prepare_value(Value) when is_float(Value) -> io_lib:format("~p", [Value]);
+prepare_value(Value) when is_boolean(Value) -> atom_to_list(Value);
 prepare_value(Value) when is_binary(Value) -> prepare_value(unicode:characters_to_list(Value));
 prepare_value(Value) when is_list(Value) -> ["'", Value, "'"].
 

--- a/test/where_tests.erl
+++ b/test/where_tests.erl
@@ -160,5 +160,15 @@ where_test_() ->
          {select, [], "test", [{where, [{"id", between, 1, 10}]}]},
          %%
          <<"SELECT * FROM test WHERE id BETWEEN 1 AND 10">>
+       },
+       {
+         %%
+         {select, [], "test", [{where, [{"id", is, not_null},
+                                        {"col1", is, null},
+                                        {"col2", is, {distinct_from, "wasd"}},
+                                        {"col3", is, true}]}]},
+         %%
+         <<"SELECT * FROM test WHERE id IS NOT NULL AND col1 IS NULL "
+           "AND col2 IS DISTINCT FROM 'wasd' AND col3 IS true">>
        }
       ]).


### PR DESCRIPTION
I actualy need it for filtering by nullable columns. Because evaluating `column <> 'my_value'` will return `null` if column is null.

http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#operator_equal-to
https://www.postgresql.org/docs/current/static/functions-comparison.html#FUNCTIONS-COMPARISON-PRED-TABLE
