### PR TITLE
Allow 'raw' values

### DIFF
--- a/src/erma_utils.erl
+++ b/src/erma_utils.erl
@@ -68,6 +68,7 @@ prepare_value({pl, _} = V) -> throw({not_resolved_placeholder, V});
 prepare_value({date, D}) -> ["'", erma_utils:format_date(D), "'"];
 prepare_value({time, T}) ->  ["'", erma_utils:format_time(T), "'"];
 prepare_value({datetime, DT}) ->  ["'", erma_utils:format_datetime(DT), "'"];
+prepare_value({raw, Raw}) ->  Raw;
 prepare_value("?") -> "?"; % mysql placeholder
 prepare_value([$$ | Rest] = Value) -> % postgresql placeholder
     case string:to_integer(Rest) of

--- a/test/erma_tests.erl
+++ b/test/erma_tests.erl
@@ -141,6 +141,14 @@ where_test() ->
            "AND (NOT (user_id = 20 OR user_id = 30)) ",
            "AND \"state\" IN ('active', 'suspended', 'unknown')">>,
     ?assertEqual(S3, erma:build(Q3)),
+
+    Q4 = {select,
+          [{raw, "CASE WHEN op = 'increment' THEN 1 ELSE -1 END"}],
+          "operations",
+          [{where, [{"amount", '<', {raw, "(SELECT avg(amount) FROM operations)"}}]}]},
+    S4 = <<"SELECT CASE WHEN op = 'increment' THEN 1 ELSE -1 END FROM operations "
+           "WHERE amount < (SELECT avg(amount) FROM operations)">>,
+    ?assertEqual(S4, erma:build(Q4)),
     ok.
 
 


### PR DESCRIPTION
Useful when you want to use some complex expressions in contexts where `value` is used. (CASE or IF expressions, some function calls, subqueries)
