### PR TITLE
add support of SQL functions

### DIFF
--- a/include/erma.hrl
+++ b/include/erma.hrl
@@ -4,7 +4,8 @@
                  {date, calendar:date()} |
                  {time, calendar:time()} |
                  {datetime, calendar:datetime()} |
-                 {pl, term()}. % placeholder
+                 {pl, term()} | % placeholder
+                 function_call().
 
 -type select() :: select | select_distinct.
 
@@ -12,7 +13,12 @@
 
 -type agg_fun() :: atom().
 
--type field() :: name() | {name(), as, name()} | {raw, name()} | {agg_fun(), name()} | {agg_fun(), name(), as, name()}.
+-type field() :: name() |
+                 {name(), as, name()} |
+                 {raw, name()} |
+                 {agg_fun(), name()} |
+                 {agg_fun(), name(), as, name()} |
+                 function_call().
 
 -type joins() :: {joins, [join()]}.
 -type join() :: {join_type(), join_tables()} |
@@ -24,6 +30,8 @@
 -type where() :: {where, [where_condition()]}.
 
 -type where_action() :: '=' | '<>' | '<' | lt | '>' | gt | '>=' | '<=' | like.
+
+-type where_key() :: name() | function_call().
 
 -type where_value() :: value() | select_query().
 
@@ -47,6 +55,8 @@
 -type limit() :: {limit, limit_value()} | {offset, limit_value(), limit, limit_value()}.
 
 -type returning() :: {returning, id} | {returning, [name()]}.
+
+-type function_call() :: {function, name(), [value()]}.
 
 -type select_query() :: {select(), [field()], table_name()} |
                         {select(), [field()], table_name(),

--- a/test/delete_tests.erl
+++ b/test/delete_tests.erl
@@ -22,5 +22,11 @@ delete_test_() ->
          {delete, users, [{where, [{"id", 3}]}]},
          %%
          <<"DELETE FROM users WHERE id = 3">>
+       },
+       {
+         %%
+         {delete, users, [{where, [{{function, calculate_rating, ["created_at", "score"]}, '>', 100}]}]},
+         %%
+         <<"DELETE FROM users WHERE calculate_rating(created_at, score) > 100">>
        }
       ]).

--- a/test/insert_tests.erl
+++ b/test/insert_tests.erl
@@ -50,5 +50,11 @@ insert_test_() ->
          {insert_rows, "users", [], [[1, "Bob", "Dou", 25], [2, "Bill", "Foo", 31]]},
          %%
          <<"INSERT INTO users VALUES (1, 'Bob', 'Dou', 25), (2, 'Bill', 'Foo', 31)">>
+       },
+       {
+         %%
+         {insert_rows, "users", [], [[1, "Bob", "Dou", {function, now, []}], [2, "Bill", "Foo", {function, now, []}]]},
+         %%
+         <<"INSERT INTO users VALUES (1, 'Bob', 'Dou', now()), (2, 'Bill', 'Foo', now())">>
        }
       ]).

--- a/test/select_tests.erl
+++ b/test/select_tests.erl
@@ -177,5 +177,71 @@ select_test_() ->
          <<"SELECT SUM(id) ",
            "FROM \"user\" ",
            "WHERE fname <> 'Bob'">>
+       },
+       {
+         %%
+         {select, [{sum, "id"}], user},
+         %%
+         <<"SELECT SUM(id) FROM \"user\"">>
+       },
+       {
+         %%
+         {select, [{sum, "id", as, "total"}], user},
+         %%
+         <<"SELECT SUM(id) AS total FROM \"user\"">>
+       },
+       {
+         %%
+         {select, [{function, now, []}], user},
+         %%
+         <<"SELECT now() FROM \"user\"">>
+       },
+       {
+         %%
+         {select, [{function, to_char, ["created_at", <<"HH24:MI:SS">>]}], user},
+         %%
+         <<"SELECT to_char(created_at, 'HH24:MI:SS') FROM \"user\"">>
+       },
+       {
+         %%
+         {select, [{function, age, [{function, now, []}, "created_at"]}], user},
+         %%
+         <<"SELECT age(now(), created_at) FROM \"user\"">>
+       },
+       {
+         %%
+         {select, ["id"], user,
+           [{where, [{"created_at", '<', {function, now, []}}]}]},
+         %%
+         <<"SELECT id ",
+           "FROM \"user\" ",
+           "WHERE created_at < now()">>
+       },
+       {
+         %%
+         {select, ["id"], user,
+           [{where, [{{function, calculate_rating, ["created_at", "score"]}, '>', 100}]}]},
+         %%
+         <<"SELECT id ",
+           "FROM \"user\" ",
+           "WHERE calculate_rating(created_at, score) > 100">>
+       },
+       {
+         %%
+         {select, ["id"], user,
+           [{where, [{{function, calculate_rating, [{function, now, []}, "score"]}, '>', 100}]}]},
+         %%
+         <<"SELECT id ",
+           "FROM \"user\" ",
+           "WHERE calculate_rating(now(), score) > 100">>
+       },
+       {
+         %%
+         {select, ["id"], user,
+           [{where, [{{function, calculate_rating, ["user.created_at", "user.score"]}, '>', 100}]}]},
+         %%
+         <<"SELECT id ",
+           "FROM \"user\" ",
+           "WHERE calculate_rating(user.created_at, user.score) > 100">>
        }
       ]).

--- a/test/update_tests.erl
+++ b/test/update_tests.erl
@@ -46,5 +46,26 @@ update_test_() ->
          {update, "users", [{"first", "Chris"}, {"last", "?"}], [{where, [{"id", "?"}]}]},
          %%
          <<"UPDATE users SET \"first\" = 'Chris', \"last\" = ? WHERE id = ?">>
+       },
+       {
+         %%
+         {update, "users", [{"logged_out", {function, now, []}}], [{where, [{"id", 3}]}]},
+         %%
+         <<"UPDATE users SET logged_out = now() WHERE id = 3">>
+       },
+       {
+         %%
+         {update, "users", [{"rating", {function, calculate_rating, [{function, now, []}, "score"]}}], [{where, [{"id", 3}]}]},
+         %%
+         <<"UPDATE users SET rating = calculate_rating(now(), score) WHERE id = 3">>
+       },
+       {
+         %%
+         {update, "users",
+           [{"status", 2}],
+           [{where, [{{function, calculate_rating, ["created_at", "score"]}, '>', 100}]}]
+         },
+         %%
+         <<"UPDATE users SET \"status\" = 2 WHERE calculate_rating(created_at, score) > 100">>
        }
       ]).


### PR DESCRIPTION
Fixes #6 
Adds support of SQL functions to 
- WHERE clause of select, update, delete
- VALUES clause of insert
- SET clause of update
- columns clause of select

Function calls are declared like: `{function, concat, ["abc", "def"]}`
There are more examples in tests.