### PR TITLE
Added support for custom operators in where filters

### DIFF
--- a/src/erma.erl
+++ b/src/erma.erl
@@ -318,7 +318,9 @@ build_where_condition({Key, is, Is}, Database) ->
 build_where_condition({Key, between, Value1, Value2}, Database) ->
     [build_where_key(Key, Database), " BETWEEN ", build_where_value(Value1, Database), " AND ", build_where_value(Value2, Database)];
 build_where_condition({Key, Value}, Database) ->
-    [build_where_key(Key, Database), " = ", build_where_value(Value, Database)].
+    [build_where_key(Key, Database), " = ", build_where_value(Value, Database)];
+build_where_condition({Key, Op, Value}, Database) when is_atom(Op) ->
+    [build_where_key(Key, Database), erlang:atom_to_list(Op), build_where_value(Value, Database)].
 
 build_is(PrepKey, null, _) ->
     [PrepKey, " IS NULL"];

--- a/test/where_tests.erl
+++ b/test/where_tests.erl
@@ -170,5 +170,20 @@ where_test_() ->
          %%
          <<"SELECT * FROM test WHERE id IS NOT NULL AND col1 IS NULL "
            "AND col2 IS DISTINCT FROM 'wasd' AND col3 IS true">>
+       },
+
+       %% tests for custom operators, see PostgreSQL manual for more examples:
+       %% https://www.postgresql.org/docs/10/functions-array.html
+       {
+         %%
+         {select, [], "test", [{where, [{"ids", '&&', "{1, 2, 3}" }]}]},
+         %%
+         <<"SELECT * FROM test WHERE ids&&'{1, 2, 3}'">>
+       },
+       {
+         %%
+         {select, [], "test", [{where, [{"ids", '||', 10 }]}]},
+         %%
+         <<"SELECT * FROM test WHERE ids||10">>
        }
       ]).


### PR DESCRIPTION
Patch adds support for custom operators in where clause. I use it for PostgreSQL array operators, see https://www.postgresql.org/docs/10/functions-array.html